### PR TITLE
multiboot: Add multi-boot

### DIFF
--- a/kernel/include/multiboot.h
+++ b/kernel/include/multiboot.h
@@ -1,0 +1,110 @@
+#ifndef MULTIBOOT_H_RKNBOMGQ
+#define MULTIBOOT_H_RKNBOMGQ
+
+#include <types.h>
+
+/* magic numbers for multiboot. these help us verify that multiboot structure is
+ * indeed valid. */
+#define MULTIBOOT_MAGIC                 0x1BADB002
+#define MULTIBOOT_EAX_MAGIC             0x2BADB002
+
+#define MULTIBOOT_MOD_ALIGN             0x00001000
+#define MULTIBOOT_INFO_ALIGN            0x00000004
+
+/* flags for multiboot_info */
+#define MULTIBOOT_FLAG_MEMORY           0x00000001
+#define MULTIBOOT_FLAG_BOOTDEV          0x00000002
+#define MULTIBOOT_FLAG_CMDLINE          0x00000004
+#define MULTIBOOT_FLAG_MODS             0x00000008
+#define MULTIBOOT_FLAG_AOUT_SYMS        0x00000010
+#define MULTIBOOT_FLAG_ELF_SHDR         0X00000020
+#define MULTIBOOT_FLAG_MEM_MAP          0x00000040
+#define MULTIBOOT_FLAG_DRIVE_INFO       0x00000080
+#define MULTIBOOT_FLAG_CONFIG_TABLE     0x00000100
+#define MULTIBOOT_FLAG_BOOT_LOADER_NAME 0x00000200
+#define MULTIBOOT_FLAG_APM_TABLE        0x00000400
+#define MULTIBOOT_FLAG_VBE_INFO         0x00000800
+#define MULTIBOOT_FLAG_FRAMEBUFFER_INFO 0x00001000
+
+/* flags for multiboot framebuffer type */
+#define MULTIBOOT_FB_TYPE_INDEXED       0x00000000
+#define MULTIBOOT_FB_TYPE_RGB           0x00000001
+#define MULTIBOOT_FB_TYPE_EGA_TEXT      0x00000002
+
+typedef struct _multiboot_info_t {
+  uint32_t flags;
+
+  uint32_t mem_lower;
+  uint32_t mem_upper;
+
+  uint32_t boot_device;
+
+  uint32_t cmdline;
+
+  uint32_t mods_count;
+  uint32_t mods_addr;
+
+  union {
+    struct {
+      uint32_t num;
+      uint32_t size;
+      uint32_t addr;
+      uint32_t shndx;
+    } __attribute__((packed)) efl_sec;
+
+    struct {
+      uint32_t tabsize;
+      uint32_t strsize;
+      uint32_t addr;
+      uint32_t reserved;
+    } __attribute__((packed)) aout_sym;
+  };
+
+  uint32_t mmap_len;
+  uint32_t mmap_addr;
+
+  uint32_t drives_len;
+  uint32_t driver_addr;
+
+  uint32_t config_table;
+
+  uint32_t bootloader_name;
+
+  uint32_t apm_table;
+
+  struct {
+    uint32_t control_info;
+    uint32_t mode_info;
+    uint16_t mode;
+    uint16_t interface_seg;
+    uint16_t interface_off;
+    uint16_t interface_len;
+  } __attribute__((packed)) vbe;
+
+  struct {
+    uint64_t addr;
+    uint32_t pitch;
+    uint32_t width;
+    uint32_t height;
+    uint8_t  bpp;
+    uint8_t  type;
+
+    union {
+      struct {
+        uint32_t addr;
+        uint16_t num_colors;
+      } __attribute__((packed)) palette;
+
+      struct {
+        uint8_t red_field_position;
+        uint8_t red_mask_size;
+        uint8_t green_field_position;
+        uint8_t green_mask_size;
+        uint8_t blue_field_position;
+        uint8_t blue_mask_size;
+      } __attribute__((packed));
+    };
+  } __attribute__((packed)) framebuffer;
+} __attribute__((packed)) multiboot_info_t;
+
+#endif /* end of include guard: MULTIBOOT_H_RKNBOMGQ */

--- a/kernel/include/multiboot.h
+++ b/kernel/include/multiboot.h
@@ -107,4 +107,7 @@ typedef struct _multiboot_info_t {
   } __attribute__((packed)) framebuffer;
 } __attribute__((packed)) multiboot_info_t;
 
+
+void multiboot_dump_info(multiboot_info_t *info);
+
 #endif /* end of include guard: MULTIBOOT_H_RKNBOMGQ */

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -1,12 +1,13 @@
 #include <kio.h>
 #include <logger.h>
+#include <multiboot.h>
 
 #include "io/video/video.h"
 #include "io/serial/serial.h"
 #include "interrupt/interrupt.h"
 #include "memory/gdt.h"
 
-extern void kmain()
+extern void kmain(multiboot_info_t *multiboot_info, uint32_t multiboot_magic)
 {
   video_clear();
 

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -11,6 +11,8 @@ extern void kmain(multiboot_info_t *multiboot_info, uint32_t multiboot_magic)
 {
   video_clear();
 
+  multiboot_dump_info(multiboot_info);
+
   klog(LOG_DEBUG, "\nInitializing Serial ports... ");
   serial_init(SERIAL_PORT1);
   serial_init(SERIAL_PORT2);

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -17,7 +17,8 @@ OBJS          = kernel.o \
                 io/video/video.o \
                 io/serial/serial.o \
                 io/io.o \
-                io/kio.o
+                io/kio.o \
+                util/multiboot.o
 
 INCLUDE       = util/types.h \
                 interrupt/interrupt.h \

--- a/kernel/util/multiboot.c
+++ b/kernel/util/multiboot.c
@@ -1,0 +1,20 @@
+#include <multiboot.h>
+#include <logger.h>
+
+void multiboot_dump_info(multiboot_info_t *info)
+{
+  klog(LOG_INFO, "------------ MULTIBOOT DUMP ------------\n");
+  klog(LOG_INFO, "Multiboot header: 0x%x\n", info);
+  klog(LOG_INFO, "flags           : 0x%x\n", info -> flags);
+  klog(LOG_INFO, "mem lower       : 0x%x\n", info -> mem_lower);
+  klog(LOG_INFO, "mem upper       : 0x%x\n", info -> mem_upper);
+  klog(LOG_INFO, "boot device     : 0x%x\n", info -> boot_device);
+  klog(LOG_INFO, "cmdline         : 0x%x\n", info -> cmdline);
+  klog(LOG_INFO, "module count    : 0x%x\n", info -> mods_count);
+  klog(LOG_INFO, "module address  : 0x%x\n", info -> mods_addr);
+  klog(LOG_INFO, "mem map len     : 0x%x\n", info -> mmap_len);
+  klog(LOG_INFO, "mem map addr    : 0x%x\n", info -> mmap_addr);
+  klog(LOG_INFO, "config table    : 0x%x\n", info -> config_table);
+  klog(LOG_INFO, "bootloader name : 0x%x\n", info -> bootloader_name);
+  klog(LOG_INFO, "----------------------------------------\n");
+}


### PR DESCRIPTION
Parse and display multiboot information. This information will be used for various other things including memory mapping (which is required for paging, malloc etc.).