### PR TITLE
build: Add docker-compose for local build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:xenial
+
+# Configure environment for tzdata
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install build tools
+RUN apt-get update -y \
+    && apt-get install -y \
+        build-essential \
+        nasm \
+        flex \
+        bison \
+        texinfo \
+        wget \
+        curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy code
+COPY . /jazz
+WORKDIR /jazz
+
+# Build dependencies
+RUN make deps
+
+# Build
+ENTRYPOINT ["make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Install build tools
 RUN apt-get update -y \
-    && apt-get install -y \
+    && apt-get install -y --no-install-recommends \
         build-essential \
         nasm \
         flex \

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ clean:
 make lint       # run clang-tidy on source files
 ```
 
+### Troubleshooting
+**Building dependencies fails with 
+`make -j 8 g++: internal compiler error: Killed (program cc1plus)` error**
+This might be because you ran out of memory due to `make` running build in parallel. Try to change the option `-j 8` to `-j 2` and build again.
+
 ### Debug
 Aside from `qemu` and `gdb`, there is extensive logging on the serial port which
 can be accessed at `/tmp/jazz_serial1.log` file when `qemu` is started from the
@@ -47,4 +52,4 @@ The todo/plan can be found [here](https://github.com/coditva/Jazz/blob/master/TO
 
 ## License
 [MIT](https://github.com/coditva/Jazz/blob/master/LICENSE)
-&copy; 2018-present [Utkarsh Maheshwari](https://github.com/coditva)  
+&copy; 2018-present [Utkarsh Maheshwari](https://github.com/coditva)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  jazz:
+    build: .
+    image: jazz:develop
+    volumes:
+      - ./build:/jazz/build
+      - ./kernel:/jazz/kernel

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -71,7 +71,7 @@ phony 			+= configure
 configure:		config.h
 
 phony 			+= qemu
-qemu: 			all
+qemu:
 				qemu-system-x86_64 -kernel $(BIN) \
 					-serial file:///tmp/jazz_serial1.log
 


### PR DESCRIPTION
Building on MacOS is hard. Added a docker-compose file to compile the code and output the build directory. Now, I can use the image in `/build` to run qemu. 🥇